### PR TITLE
announce ssrcs for firefox (using a random cname)

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -39,7 +39,6 @@ function PeerConnection(config, constraints) {
     // EXPERIMENTAL FLAG, might get removed without notice
     // make firefox announce its ssrcs in answers
     this.enableFirefoxSSRCAnnounce = false;
-    console.log(constraints);
     if (webrtc.prefix == 'moz' && constraints && constraints.optional) {
         constraints.optional.forEach(function (constraint, idx) {
             if (constraint.enableFirefoxSSRCAnnounce) {

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -36,6 +36,18 @@ function PeerConnection(config, constraints) {
         });
     }
 
+    // EXPERIMENTAL FLAG, might get removed without notice
+    // make firefox announce its ssrcs in answers
+    this.enableFirefoxSSRCAnnounce = false;
+    console.log(constraints);
+    if (webrtc.prefix == 'moz' && constraints && constraints.optional) {
+        constraints.optional.forEach(function (constraint, idx) {
+            if (constraint.enableFirefoxSSRCAnnounce) {
+                self.enableFirefoxSSRCAnnounce = true;
+            }
+        });
+    }
+
     this.pc = new peerconn(config, constraints);
 
     this.getLocalStreams = this.pc.getLocalStreams.bind(this.pc);
@@ -411,7 +423,7 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                         // native simulcast part 2: 
                         // signal multiple tracks to the receiver
                         if (!expandedAnswer.jingle) {
-                            expandedAnswer.jingle = SJJ.toSessionJSON(answer.sdp);
+                            expandedAnswer.jingle = SJJ.toSessionJSON(expandedAnswer.sdp);
                         }
                         expandedAnswer.jingle.contents[1].description.sources.forEach(function (source, idx) {
                             if (sim.indexOf(source.ssrc) != -1) {
@@ -425,8 +437,69 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                         });
                         expandedAnswer.sdp = SJJ.toSessionSDP(expandedAnswer.jingle);
                     }
-                    self.emit('answer', expandedAnswer);
-                    cb(null, expandedAnswer);
+
+                    if (self.enableFirefoxSSRCAnnounce) {
+                        // generate fake cname and msid lines for firefox
+                        self.getStats(function (err, items) {
+                            if (items) {
+                                var ssrcs = {};
+                                ssrcs.cname = Math.random().toString(36).substring(2);
+                                ssrcs.stream = Math.random().toString(36).substring(2);
+                                items.forEach(function (item) {
+                                    if (item.id === 'outbound_rtp_audio_0') {
+                                        ssrcs.audio = item.ssrc;
+                                    } else if (item.id == 'outbound_rtp_video_1') {
+                                        ssrcs.video = item.ssrc;
+                                    }
+                                });
+                                if (ssrcs.audio || ssrcs.video) {
+                                    if (!expandedAnswer.jingle) {
+                                        expandedAnswer.jingle = SJJ.toSessionJSON(expandedAnswer.sdp);
+                                    }
+                                    if (ssrcs.audio && self.pc.getLocalStreams()[0].getAudioTracks().length) {
+                                        ssrcs.audiotrack = self.pc.getLocalStreams()[0].getAudioTracks()[0].id;
+                                        expandedAnswer.jingle.contents[0].description.sources.push({
+                                            ssrc: ssrcs.audio,
+                                            parameters: [
+                                                {
+                                                    key: "cname",
+                                                    value: ssrcs.cname
+                                                },
+                                                {
+                                                    key: "msid",
+                                                    value: [ssrcs.stream, ssrcs.audiotrack].join(' ')
+                                                }
+                                            ]
+                                        });
+                                    }
+                                    if (ssrcs.video && self.pc.getLocalStreams()[0].getVideoTracks().length) {
+                                        ssrcs.videotrack = self.pc.getLocalStreams()[0].getVideoTracks()[0].id;
+                                        expandedAnswer.jingle.contents[1].description.sources.push({
+                                            ssrc: ssrcs.video,
+                                            parameters: [
+                                                {
+                                                    key: "cname",
+                                                    value: ssrcs.cname
+                                                },
+                                                {
+                                                    key: "msid",
+                                                    value: [ssrcs.stream, ssrcs.videotrack].join(' ')
+                                                }
+                                            ]
+                                        });
+                                    }
+                                    expandedAnswer.sdp = SJJ.toSessionSDP(expandedAnswer.jingle);
+                                }
+                            }
+                            // in case of errors just emit unmodified
+                            self.emit('answer', expandedAnswer);
+                            cb(null, expandedAnswer);
+                        });
+
+                    } else {
+                        self.emit('answer', expandedAnswer);
+                        cb(null, expandedAnswer);
+                    }
                 },
                 function (err) {
                     self.emit('error', err);

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -279,17 +279,17 @@ PeerConnection.prototype.handleOffer = function (offer, cb) {
             offer.jingle.contents.forEach(function (content) {
                 if (content.name === 'video') {
                     var sources = content.description.sources || [];
-                    if (sources.length === 0 || sources[0].ssrc !== "3735928559") {
+                    if (sources.length === 0 || sources[0].ssrc !== '3735928559') {
                         sources.unshift({
-                            ssrc: "3735928559", // 0xdeadbeef
+                            ssrc: '3735928559', // 0xdeadbeef
                             parameters: [
                                 {
-                                    key: "cname",
-                                    value: "deadbeef"
+                                    key: 'cname',
+                                    value: 'deadbeef'
                                 },
                                 {
-                                    key: "msid",
-                                    value: "mixyourfecintothis please"
+                                    key: 'msid',
+                                    value: 'mixyourfecintothis please'
                                 }
                             ]
                         });
@@ -442,8 +442,6 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                         self.getStats(function (err, items) {
                             if (items) {
                                 var ssrcs = {};
-                                ssrcs.cname = Math.random().toString(36).substring(2);
-                                ssrcs.stream = Math.random().toString(36).substring(2);
                                 items.forEach(function (item) {
                                     if (item.id === 'outbound_rtp_audio_0') {
                                         ssrcs.audio = item.ssrc;
@@ -452,6 +450,8 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                                     }
                                 });
                                 if (ssrcs.audio || ssrcs.video) {
+                                    ssrcs.cname = Math.random().toString(36).substring(2);
+                                    ssrcs.stream = self.pc.getLocalStreams()[0].id || Math.random().toString(36).substring(2);
                                     if (!expandedAnswer.jingle) {
                                         expandedAnswer.jingle = SJJ.toSessionJSON(expandedAnswer.sdp);
                                     }
@@ -461,11 +461,11 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                                             ssrc: ssrcs.audio,
                                             parameters: [
                                                 {
-                                                    key: "cname",
+                                                    key: 'cname',
                                                     value: ssrcs.cname
                                                 },
                                                 {
-                                                    key: "msid",
+                                                    key: 'msid',
                                                     value: [ssrcs.stream, ssrcs.audiotrack].join(' ')
                                                 }
                                             ]
@@ -477,11 +477,11 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                                             ssrc: ssrcs.video,
                                             parameters: [
                                                 {
-                                                    key: "cname",
+                                                    key: 'cname',
                                                     value: ssrcs.cname
                                                 },
                                                 {
-                                                    key: "msid",
+                                                    key: 'msid',
                                                     value: [ssrcs.stream, ssrcs.videotrack].join(' ')
                                                 }
                                             ]

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -443,10 +443,8 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                             if (items) {
                                 var ssrcs = {};
                                 items.forEach(function (item) {
-                                    if (item.id === 'outbound_rtp_audio_0') {
-                                        ssrcs.audio = item.ssrc;
-                                    } else if (item.id == 'outbound_rtp_video_1') {
-                                        ssrcs.video = item.ssrc;
+                                    if (item.type == "outboundrtp" && !item.isRemote) {
+                                        ssrcs[item.id.split('_')[2]] = item.ssrc;
                                     }
                                 });
                                 if (ssrcs.audio || ssrcs.video) {


### PR DESCRIPTION
this puts the SSRCs (queried using getStats) firefox uses into the answer sdp/jingle

side-effect: chrome can show getStats values for those streams