### PR TITLE
workaround firefox addIceCandidate issue

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -74,11 +74,11 @@ function PeerConnection(config, constraints) {
     // pass in a timeout for this
     if (webrtc.prefix === 'moz') {
         if (constraints && constraints.optional) {
-            this.firefoxmakesmesad = 0;
+            this.wtFirefox = 0;
             constraints.optional.forEach(function (constraint, idx) {
                 if (constraint.andyetFirefoxMakesMeSad) {
-                    self.firefoxmakesmesad = constraint.andyetFirefoxMakesMeSad;
-                    if (self.firefoxmakesmesad > 0) {
+                    self.wtFirefox = constraint.andyetFirefoxMakesMeSad;
+                    if (self.wtFirefox > 0) {
                         self.firefoxcandidatebuffer = [];
                     }
                 }
@@ -250,7 +250,7 @@ PeerConnection.prototype.processIce = function (update, cb) {
             update.candidate.candidate = 'a=' + update.candidate.candidate;
         }
 
-        if (this.firefoxmakesmesad && this.firefoxcandidatebuffer !== null) {
+        if (this.wtFirefox && this.firefoxcandidatebuffer !== null) {
             // we cant add this yet due to https://bugzilla.mozilla.org/show_bug.cgi?id=1087551
             if (this.pc.localDescription && this.pc.localDescription.type === 'offer') {
                 this.firefoxcandidatebuffer.push(update.candidate);
@@ -483,7 +483,7 @@ PeerConnection.prototype.handleAnswer = function (answer, cb) {
     self.pc.setRemoteDescription(
         new webrtc.SessionDescription(answer),
         function () {
-            if (self.firefoxmakesmesad) {
+            if (self.wtFirefox) {
                 window.setTimeout(function () {
                     self.firefoxcandidatebuffer.forEach(function (candidate) {
                         // add candidates later
@@ -497,7 +497,7 @@ PeerConnection.prototype.handleAnswer = function (answer, cb) {
                         self._checkRemoteCandidate(candidate.candidate);
                     });
                     self.firefoxcandidatebuffer = null;
-                }, self.firefoxmakesmesad);
+                }, self.wtFirefox);
             }
             cb(null);
         },

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -69,6 +69,23 @@ function PeerConnection(config, constraints) {
         });
     }
 
+    // EXPERIMENTAL FLAG, might get removed without notice
+    // working around https://bugzilla.mozilla.org/show_bug.cgi?id=1087551
+    // pass in a timeout for this
+    if (webrtc.prefix === 'moz') {
+        if (constraints && constraints.optional) {
+            this.firefoxmakesmesad = 0;
+            constraints.optional.forEach(function (constraint, idx) {
+                if (constraint.andyetFirefoxMakesMeSad) {
+                    self.firefoxmakesmesad = constraint.andyetFirefoxMakesMeSad;
+                    if (self.firefoxmakesmesad > 0) {
+                        self.firefoxcandidatebuffer = [];
+                    }
+                }
+            });
+        }
+    }
+
 
     this.pc = new peerconn(config, constraints);
 
@@ -231,6 +248,14 @@ PeerConnection.prototype.processIce = function (update, cb) {
         // working around https://code.google.com/p/webrtc/issues/detail?id=3669
         if (update.candidate && update.candidate.candidate.indexOf('a=') !== 0) {
             update.candidate.candidate = 'a=' + update.candidate.candidate;
+        }
+
+        if (this.firefoxmakesmesad && this.firefoxcandidatebuffer !== null) {
+            // we cant add this yet due to https://bugzilla.mozilla.org/show_bug.cgi?id=1087551
+            if (this.pc.localDescription && this.pc.localDescription.type === 'offer') {
+                this.firefoxcandidatebuffer.push(update.candidate);
+                return cb();
+            }
         }
 
         self.pc.addIceCandidate(
@@ -458,6 +483,22 @@ PeerConnection.prototype.handleAnswer = function (answer, cb) {
     self.pc.setRemoteDescription(
         new webrtc.SessionDescription(answer),
         function () {
+            if (self.firefoxmakesmesad) {
+                window.setTimeout(function () {
+                    self.firefoxcandidatebuffer.forEach(function (candidate) {
+                        // add candidates later
+                        self.pc.addIceCandidate(
+                            new webrtc.IceCandidate(candidate),
+                            function () { },
+                            function (err) {
+                                self.emit('error', err);
+                            }
+                        );
+                        self._checkRemoteCandidate(candidate.candidate);
+                    });
+                    self.firefoxcandidatebuffer = null;
+                }, self.firefoxmakesmesad);
+            }
             cb(null);
         },
         cb

--- a/test/uglyfirefoxworkaround.js
+++ b/test/uglyfirefoxworkaround.js
@@ -1,0 +1,71 @@
+/* testing basic session establishment */
+var test = require('tape');
+var PeerConnection = require('../rtcpeerconnection');
+
+test('firefox workaround', function (t) {
+    var pc1, pc2;
+    pc1 = new PeerConnection(null, {
+        optional:[
+            {
+                andyetFirefoxMakesMeSad: 1000
+            }
+        ]
+    });
+    pc2 = new PeerConnection(null, {
+        optional:[
+            {
+                andyetFirefoxMakesMeSad: 1000
+            }
+        ]
+    });
+
+    pc1.on('ice', function (candidate) {
+        pc2.processIce(candidate);
+    });
+    pc2.on('ice', function (candidate) {
+        pc1.processIce(candidate);
+    });
+
+    pc1.on('iceConnectionStateChange', function () {
+        console.log('pc1 iceConnectionStateChange', pc1.iceConnectionState);
+        if (pc1.iceConnectionState == 'connected') {
+            t.pass('P2P connection established');
+            t.end();
+        }
+        // FIXME: also look for https://code.google.com/p/webrtc/issues/detail?id=1414
+    });
+    pc2.on('iceConnectionStateChange', function () {
+        console.log('pc2 iceConnectionStateChange', pc2.iceConnectionState);
+    });
+
+    pc1.offer(function (err, offer) {
+        if (err) {
+            t.fail('failed to create offer');
+            return;
+        }
+        t.pass('created offer');
+        pc2.handleOffer(offer, function (err) {
+            if (err) {
+                // handle error
+                t.fail('error handling offer');
+                return;
+            }
+            t.pass('handled offer');
+
+            pc2.answer(function (err, answer) {
+                if (err) {
+                    t.fail('error handling answer');
+                    return;
+                }
+                t.pass('created answer');
+                pc1.handleAnswer(answer, function (err) {
+                    if (err) {
+                        t.fail('failed to handle answer');
+                        return;
+                    }
+                    t.pass('handled answer');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Interestingly, the test connects before adding the ice candidates from PC2 to PC1 so maybe this doesn't affect the setup latency as much as I am afraid it will.