### PR TITLE
When two arguments are passed, but the constraints are falsy, use defaults

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -277,7 +277,7 @@ PeerConnection.prototype.processIce = function (update, cb) {
 PeerConnection.prototype.offer = function (constraints, cb) {
     var self = this;
     var hasConstraints = arguments.length === 2;
-    var mediaConstraints = hasConstraints ? constraints : {
+    var mediaConstraints = hasConstraints && constraints ? constraints : {
             mandatory: {
                 OfferToReceiveAudio: true,
                 OfferToReceiveVideo: true
@@ -450,7 +450,7 @@ PeerConnection.prototype.answer = function (constraints, cb) {
     var self = this;
     var hasConstraints = arguments.length === 2;
     var callback = hasConstraints ? cb : constraints;
-    var mediaConstraints = hasConstraints ? constraints : {
+    var mediaConstraints = hasConstraints && constraints ? constraints : {
             mandatory: {
                 OfferToReceiveAudio: true,
                 OfferToReceiveVideo: true


### PR DESCRIPTION
This solves a bug I experienced wherein using Jingle.js, calling `session.start` with no arguments caused constraints to be undefined instead of using the defaults. This could be changed in Jingle to not send an undefined value for constraints when not provided, but given that the default check in RTCPeerConnection is allowing defaults when not provided, it seems logical to use the defaults when the constraints are undefined.