### PR TITLE
Check for bandwidth.bandwidth being empty for adding b=AS line

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -417,7 +417,7 @@ PeerConnection.prototype.handleOffer = function (offer, cb) {
         if (self.restrictBandwidth > 0) {
             if (offer.jingle.contents.length >= 2 && offer.jingle.contents[1].name === 'video') {
                 var content = offer.jingle.contents[1];
-                var hasBw = content.application && content.application.bandwidth;
+                var hasBw = content.application && content.application.bandwidth && content.application.bandwidth.bandwidth;
                 if (!hasBw) {
                     offer.jingle.contents[1].application.bandwidth = { type: 'AS', bandwidth: self.restrictBandwidth.toString() };
                     offer.sdp = SJJ.toSessionSDP(offer.jingle, {


### PR DESCRIPTION
This PR handles an issue I'm running into when using RTCPeerConnection as part of stanza.io where setting the `andyetRestrictBandwidth` constraint (or simply setting the restrictBandwidth property) doesn't result in a `b=AS` line.

The issue is that [in rtcpeerconnection.js](https://github.com/otalk/RTCPeerConnection/blob/392bf5ca0d72c042369f13aafc186d416866b739/rtcpeerconnection.js#L420), the `b=AS:` line is only added if a bandwidth section does not exist in the offer, which is determined by checking if `content.application && content.application.bandwidth` is truthy. 

The problem in my case is that `content.application.bandwidth`does exist, but `content.application.bandwidth.bandwidth` is an empty string. 

This PR adds `content.application.bandwidth.bandwidth` to the conditional for an offer to be considered as already having a bandwidth section.