### PR TITLE
return on have local offer

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -243,7 +243,10 @@ PeerConnection.prototype.processIce = function (update, cb) {
 
     // ignore any added ice candidates to avoid errors. why does the
     // spec not do this?
-    if (this.pc.signalingState === 'closed') return cb();
+    if (this.pc.signalingState === 'closed' ||
+            this.pc.signalingState === 'have-local-offer') {
+        return cb();
+    }
 
     if (update.contents || (update.jingle && update.jingle.contents)) {
         var contentNames = pluck(this.remoteDescription.contents, 'name');

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -243,9 +243,25 @@ PeerConnection.prototype.processIce = function (update, cb) {
 
     // ignore any added ice candidates to avoid errors. why does the
     // spec not do this?
-    if (this.pc.signalingState === 'closed' ||
-            this.pc.signalingState === 'have-local-offer') {
+    if (this.pc.signalingState === 'closed') {
         return cb();
+    }
+
+    var earlyIceUpdates = this.earlyIceUpdates || [];
+    var logger = this.config.logger || console;
+
+    if (this.pc.signalingState === 'have-local-offer') {
+        earlyIceUpdates.push(update);
+
+        logger.log('Caching early ICE update', update);
+        return cb();
+    } else {
+        earlyIceUpdates.forEach(function (u) {
+            this.processIce(u, function () {
+                logger.log('Processed early ICE update', u);
+            });
+        });
+        this.earlyIceUpdates = [];
     }
 
     if (update.contents || (update.jingle && update.jingle.contents)) {


### PR DESCRIPTION
Resolves #67 Though I'm not sure if a more general sense (i.e., `!== 'stable'`) might make more sense. Thoughts?