### PR TITLE
return copy of answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "license": "MIT",
   "dependencies": {
+    "lodash.clonedeep": "^4.3.2",
     "sdp-jingle-json": "^3.0.0",
     "traceablepeerconnection": "^1.1.6",
     "webrtc-adapter": "^1.0",

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -3,6 +3,7 @@ var SJJ = require('sdp-jingle-json');
 var WildEmitter = require('wildemitter');
 var Peerconn = require('traceablepeerconnection');
 var adapter = require('webrtc-adapter');
+var cloneDeep = require('lodash.clonedeep');
 
 function PeerConnection(config, constraints) {
     var self = this;
@@ -660,8 +661,9 @@ PeerConnection.prototype._answer = function (constraints, cb) {
             };
             if (self.assumeSetLocalSuccess) {
                 // not safe to do when doing simulcast mangling
-                self.emit('answer', expandedAnswer);
-                cb(null, expandedAnswer);
+                var copy = cloneDeep(expandedAnswer);
+                self.emit('answer', copy);
+                cb(null, copy);
             }
             self._candidateBuffer = [];
             self.pc.setLocalDescription(answer,
@@ -707,8 +709,9 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                         }
                     });
                     if (!self.assumeSetLocalSuccess) {
-                        self.emit('answer', expandedAnswer);
-                        cb(null, expandedAnswer);
+                        var copy = cloneDeep(expandedAnswer);
+                        self.emit('answer', copy);
+                        cb(null, copy);
                     }
                 },
                 function (err) {


### PR DESCRIPTION
We ran into some interesting things that took us some time to track down. This library is used by `jingle-media-session`. The answer returned by `RTCPeerConnection.answer()` was being manipulated by this external library and since `RTCPeerConnection.localDescription = answer` it was also changing the localDescription which caused problems on subsequent negotiations.