### PR TITLE
Emitted objects should be immutable to consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "license": "MIT",
   "dependencies": {
+    "lodash.clonedeep": "^4.3.2",
     "sdp-jingle-json": "^3.0.0",
     "traceablepeerconnection": "^1.1.6",
     "webrtc-adapter": "^1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtcpeerconnection",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A tiny browser module that normalizes and simplifies the API for WebRTC peer connections.",
   "main": "rtcpeerconnection.js",
   "repository": {

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -3,6 +3,7 @@ var SJJ = require('sdp-jingle-json');
 var WildEmitter = require('wildemitter');
 var Peerconn = require('traceablepeerconnection');
 var adapter = require('webrtc-adapter');
+var cloneDeep = require('lodash.clonedeep');
 
 function PeerConnection(config, constraints) {
     var self = this;
@@ -660,8 +661,9 @@ PeerConnection.prototype._answer = function (constraints, cb) {
             };
             if (self.assumeSetLocalSuccess) {
                 // not safe to do when doing simulcast mangling
-                self.emit('answer', expandedAnswer);
-                cb(null, expandedAnswer);
+                var copy = cloneDeep(expandedAnswer);
+                self.emit('answer', copy);
+                cb(null, copy);
             }
             self._candidateBuffer = [];
             self.pc.setLocalDescription(answer,
@@ -707,8 +709,9 @@ PeerConnection.prototype._answer = function (constraints, cb) {
                         }
                     });
                     if (!self.assumeSetLocalSuccess) {
-                        self.emit('answer', expandedAnswer);
-                        cb(null, expandedAnswer);
+                        var copy = cloneDeep(expandedAnswer);
+                        self.emit('answer', copy);
+                        cb(null, copy);
                     }
                 },
                 function (err) {


### PR DESCRIPTION
I noticed that jingle-media-session does some manipulation of the object emitted by these events, which was later causing things to break. Clone the objects before emitting them so they are immutable by consumers.