### PR TITLE
Prevent exception when used with React Native

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -114,7 +114,7 @@ function PeerConnection(config, constraints) {
 
     this.pc = new RTCPeerConnection(config, constraints);
 
-    if (this.pc.getLocalStreams) {
+    if (typeof this.pc.getLocalStreams === 'function') {
         this.getLocalStreams = this.pc.getLocalStreams.bind(this.pc);
     } else {
         this.getLocalStreams = function () {

--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -114,7 +114,14 @@ function PeerConnection(config, constraints) {
 
     this.pc = new RTCPeerConnection(config, constraints);
 
-    this.getLocalStreams = this.pc.getLocalStreams.bind(this.pc);
+    if (this.pc.getLocalStreams) {
+        this.getLocalStreams = this.pc.getLocalStreams.bind(this.pc);
+    } else {
+        this.getLocalStreams = function () {
+            return [];
+        };
+    }
+
     this.getRemoteStreams = this.pc.getRemoteStreams.bind(this.pc);
     this.addStream = this.pc.addStream.bind(this.pc);
 


### PR DESCRIPTION
Turns out that the RTCPeerConnection shim in React Native does not
expose a `getLocalStreams` method, so trying to make a bound proxy
would blow up.