### PR TITLE
Safari 11 bugfix: usage of promise-based version for pc.createOffer

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -387,7 +387,7 @@ PeerConnection.prototype.offer = function (constraints, cb) {
     if (this.pc.signalingState === 'closed') return cb('Already closed');
 
     // Actually generate the offer
-    this.pc.createOffer(
+    this.pc.createOffer( mediaConstraints ).then(
         function (offer) {
             // does not work for jingle, but jingle.js doesn't need
             // this hack...
@@ -444,8 +444,7 @@ PeerConnection.prototype.offer = function (constraints, cb) {
         function (err) {
             self.emit('error', err);
             cb(err);
-        },
-        mediaConstraints
+        }
     );
 };
 


### PR DESCRIPTION
Initial bug: https://github.com/andyet/SimpleWebRTC/issues/704

In case of callback-based version of `.createOffer` Safari 11.0.3 perceives `mediaConstraints` as 
```javascript
{
  'offerToReceiveAudio': false,
  'offerToReceiveVideo': false
}
```

But in case of promise-based version it perceives `mediaConstraints` as intended.