### PR TITLE
Drop firefox empty string candidates

### DIFF
--- a/rtcpeerconnection.js
+++ b/rtcpeerconnection.js
@@ -787,6 +787,8 @@ PeerConnection.prototype._onIce = function (event) {
         if (this.dontSignalCandidates) return;
         var ice = event.candidate;
 
+        // drop firefox empty string candidate
+        if (!ice.candidate.length) return;
         var expandedCandidate = {
             candidate: {
                 candidate: ice.candidate,


### PR DESCRIPTION
Initial issue: https://github.com/otalk/sdp-jingle-json/issues/29

These changes will prevent the error `TypeError: parts[2] is undefined` from occurring when Firefox uses empty string candidates that can't be parsed properly.